### PR TITLE
v3.3.0: Use a generic Command handler

### DIFF
--- a/bungeecord/pom.xml
+++ b/bungeecord/pom.xml
@@ -66,6 +66,11 @@
             <version>4.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.7.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>configurate-yaml</artifactId>
             <version>4.0.0</version>
@@ -106,6 +111,10 @@
                         <relocation>
                             <pattern>org.bstats</pattern>
                             <shadedPattern>com.andre601.oneversionremake.bungeecord.dependencies.bstats</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net.kyori</pattern>
+                            <shadedPattern>com.andre601.oneversionremake.bungeecord.dependencies.adventure</shadedPattern>
                         </relocation>
                     </relocations>
                     <filters>

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
@@ -18,11 +18,13 @@
 
 package com.andre601.oneversionremake.bungeecord;
 
+import com.andre601.oneversionremake.bungeecord.commands.BungeeSender;
 import com.andre601.oneversionremake.bungeecord.commands.CmdOneVersionRemake;
 import com.andre601.oneversionremake.bungeecord.listener.BungeeLoginListener;
 import com.andre601.oneversionremake.bungeecord.listener.BungeePingListener;
 import com.andre601.oneversionremake.bungeecord.logging.BungeeLogger;
 import com.andre601.oneversionremake.core.OneVersionRemake;
+import com.andre601.oneversionremake.core.commands.CommandHandler;
 import com.andre601.oneversionremake.core.enums.ProtocolVersion;
 import com.andre601.oneversionremake.core.enums.ProxyPlatform;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
@@ -42,6 +44,7 @@ public class BungeeCore extends Plugin implements PluginCore{
     
     private OneVersionRemake core;
     private final ProxyLogger logger = new BungeeLogger(getLogger());
+    private final BungeeSender sender = new BungeeSender(this.getProxy().getConsole());
     
     @Override
     public void onEnable(){
@@ -100,11 +103,6 @@ public class BungeeCore extends Plugin implements PluginCore{
     }
     
     @Override
-    public boolean reloadConfig(){
-        return core.reloadConfig();
-    }
-    
-    @Override
     public Path getPath(){
         return getDataFolder().toPath();
     }
@@ -130,7 +128,16 @@ public class BungeeCore extends Plugin implements PluginCore{
     }
     
     @Override
+    public CommandHandler getCommandHandler(){
+        return core.getCommandHandler();
+    }
+    
+    @Override
     public String getVersion(){
         return core.getVersion();
+    }
+    
+    public BungeeSender getSender(){
+        return sender;
     }
 }

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
@@ -18,7 +18,6 @@
 
 package com.andre601.oneversionremake.bungeecord;
 
-import com.andre601.oneversionremake.bungeecord.commands.BungeeSender;
 import com.andre601.oneversionremake.bungeecord.commands.CmdOneVersionRemake;
 import com.andre601.oneversionremake.bungeecord.listener.BungeeLoginListener;
 import com.andre601.oneversionremake.bungeecord.listener.BungeePingListener;
@@ -44,7 +43,6 @@ public class BungeeCore extends Plugin implements PluginCore{
     
     private OneVersionRemake core;
     private final ProxyLogger logger = new BungeeLogger(getLogger());
-    private final BungeeSender sender = new BungeeSender(this.getProxy().getConsole());
     
     @Override
     public void onEnable(){
@@ -135,9 +133,5 @@ public class BungeeCore extends Plugin implements PluginCore{
     @Override
     public String getVersion(){
         return core.getVersion();
-    }
-    
-    public BungeeSender getSender(){
-        return sender;
     }
 }

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/BungeeSender.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/BungeeSender.java
@@ -16,27 +16,41 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.andre601.oneversionremake.velocity.commands;
+package com.andre601.oneversionremake.bungeecord.commands;
 
-import com.andre601.oneversionremake.velocity.VelocityCore;
-import com.velocitypowered.api.command.SimpleCommand;
+import com.andre601.oneversionremake.core.interfaces.CmdSender;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
+import net.md_5.bungee.api.CommandSender;
 
-public class CmdOneVersionRemake implements SimpleCommand{
+public class BungeeSender implements CmdSender{
     
-    private final VelocityCore plugin;
+    private final CommandSender sender;
     
-    public CmdOneVersionRemake(VelocityCore plugin){
-        this.plugin = plugin;
+    public BungeeSender(CommandSender sender){
+        this.sender = sender;
     }
     
     @Override
-    public void execute(Invocation invocation){
-        String[] args = invocation.arguments();
-        
-        if(plugin.getSender() == null){
-            plugin.setSender(invocation.source());
-        }
-        
-        plugin.getCommandHandler().handle(plugin.getSender(), args);
+    public boolean hasPermission(String permission){
+        return sender.hasPermission(permission);
+    }
+    
+    @Override
+    public void sendMsg(){
+        sendMsg("");
+    }
+    
+    @Override
+    public void sendMsg(String msg, Object... args){
+        sendMsg(NamedTextColor.WHITE, msg, args);
+    }
+    
+    @Override
+    public void sendMsg(NamedTextColor color, String msg, Object... args){
+        sender.sendMessage(BungeeComponentSerializer.get().serialize(
+                Component.text(String.format(msg, args)).color(color)
+        ));
     }
 }

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/BungeeSender.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/BungeeSender.java
@@ -18,6 +18,7 @@
 
 package com.andre601.oneversionremake.bungeecord.commands;
 
+import com.andre601.oneversionremake.core.CommandPermissions;
 import com.andre601.oneversionremake.core.interfaces.CmdSender;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -34,7 +35,7 @@ public class BungeeSender implements CmdSender{
     
     @Override
     public boolean hasPermission(String permission){
-        return sender.hasPermission(permission);
+        return sender.hasPermission(permission) || sender.hasPermission(CommandPermissions.ADMIN);
     }
     
     @Override

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/CmdOneVersionRemake.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/CmdOneVersionRemake.java
@@ -34,6 +34,8 @@ public class CmdOneVersionRemake extends Command{
     
     @Override
     public void execute(CommandSender commandSender, String[] args){
-        plugin.getCommandHandler().handle(plugin.getSender(), args);
+        BungeeSender sender = new BungeeSender(commandSender);
+        
+        plugin.getCommandHandler().handle(sender, args);
     }
 }

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/CmdOneVersionRemake.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/commands/CmdOneVersionRemake.java
@@ -20,14 +20,8 @@ package com.andre601.oneversionremake.bungeecord.commands;
 
 import com.andre601.oneversionremake.bungeecord.BungeeCore;
 import com.andre601.oneversionremake.core.CommandPermissions;
-import com.andre601.oneversionremake.core.enums.ProtocolVersion;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
-
-import java.util.List;
 
 public class CmdOneVersionRemake extends Command{
     
@@ -40,59 +34,6 @@ public class CmdOneVersionRemake extends Command{
     
     @Override
     public void execute(CommandSender commandSender, String[] args){
-        if(args.length == 0 || args[0].equalsIgnoreCase("help")){
-            if(!commandSender.hasPermission(CommandPermissions.COMMAND_HELP)){
-                sendMsg(commandSender, NamedTextColor.RED, "Insufficient permissions!");
-                return;
-            }
-            
-            sendMsg(commandSender, "OneVersionRemake v%s", plugin.getVersion());
-            sendMsg(commandSender);
-            sendMsg(commandSender, NamedTextColor.AQUA, "/ovr help");
-            sendMsg(commandSender, NamedTextColor.GRAY, "Shows this command list.");
-            sendMsg(commandSender);
-            sendMsg(commandSender, NamedTextColor.AQUA, "/ovr reload");
-            sendMsg(commandSender, NamedTextColor.GRAY, "Reloads the configuration.");
-        }else
-        if(args[0].equalsIgnoreCase("reload")){
-            if(!commandSender.hasPermission(CommandPermissions.COMMAND_RELOAD)){
-                sendMsg(commandSender, NamedTextColor.RED, "Insufficient permissions!");
-                return;
-            }
-            
-            if(plugin.reloadConfig()){
-                List<Integer> serverProtocols = plugin.getConfigHandler().getIntList("Protocol", "Versions");
-                
-                sendMsg(commandSender, NamedTextColor.AQUA, "Loaded Minecraft Version(s):");
-                if(serverProtocols.isEmpty()){
-                    sendMsg(commandSender, NamedTextColor.RED, "None");
-                }else{
-                    sendMsg(commandSender, NamedTextColor.GRAY, ProtocolVersion.getFriendlyNames(serverProtocols, false));
-                }
-                
-                sendMsg(commandSender);
-                sendMsg(commandSender, NamedTextColor.GREEN, "Reload successful!");
-            }else{
-                sendMsg(commandSender, NamedTextColor.RED, "There was an error while reloading the config.yml");
-                sendMsg(commandSender, NamedTextColor.RED, "Please check the console for any errors and warnings.");
-            }
-        }else{
-            sendMsg(commandSender, NamedTextColor.RED, "Unknown argument \"%s\".", args[0]);
-            sendMsg(commandSender, NamedTextColor.RED, "Run \"/ovr help\" for help");
-        }
-    }
-    
-    private void sendMsg(CommandSender sender){
-        sendMsg(sender, "");
-    }
-    
-    private void sendMsg(CommandSender sender, String msg, Object... args){
-        sendMsg(sender, NamedTextColor.WHITE, msg, args);
-    }
-    
-    private void sendMsg(CommandSender sender, NamedTextColor color, String msg, Object... args){
-        sender.sendMessage(BungeeComponentSerializer.get()
-                .serialize(Component.text(String.format(msg, args)).color(color))
-        );
+        plugin.getCommandHandler().handle(plugin.getSender(), args);
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -103,6 +103,10 @@
                             <pattern>org.spongepowered.configurate</pattern>
                             <shadedPattern>com.andre601.oneversionremake.core.dependencies.configurate</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>net.kyori</pattern>
+                            <shadedPattern>com.andre601.oneversionremake.core.dependencies.adventure</shadedPattern>
+                        </relocation>
                     </relocations>
                     <filters>
                         <filter>

--- a/core/src/main/java/com/andre601/oneversionremake/core/CommandPermissions.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/CommandPermissions.java
@@ -23,8 +23,11 @@ public class CommandPermissions{
     private final static String BASE = "oneversionremake.";
     private final static String COMMAND_BASE = BASE + "command.";
     
+    // oneversionremake.admin
     public final static String ADMIN = BASE + "admin";
     
+    // oneversionremake.command.help
     public static final String COMMAND_HELP = COMMAND_BASE + "help";
+    // oneversionremake.command.reload
     public static final String COMMAND_RELOAD = COMMAND_BASE + "reload";
 }

--- a/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
@@ -18,6 +18,7 @@
 
 package com.andre601.oneversionremake.core;
 
+import com.andre601.oneversionremake.core.commands.CommandHandler;
 import com.andre601.oneversionremake.core.enums.ProtocolVersion;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
@@ -32,12 +33,14 @@ public class OneVersionRemake{
     
     private final PluginCore pluginCore;
     private final ConfigHandler configHandler;
+    private final CommandHandler commandHandler;
     
     private String version;
     
     public OneVersionRemake(PluginCore pluginCore){
         this.pluginCore = pluginCore;
         this.configHandler = new ConfigHandler(this, pluginCore.getPath());
+        this.commandHandler = new CommandHandler(this);
         
         start();
     }
@@ -58,77 +61,78 @@ public class OneVersionRemake{
         return configHandler.reload();
     }
     
+    public CommandHandler getCommandHandler(){
+        return commandHandler;
+    }
+    
     private void start(){
         loadVersion();
-        
-        ProxyLogger logger = pluginCore.getProxyLogger();
-        
-        printBanner(logger);
+        printBanner();
         
         if(configHandler.loadConfig()){
-            logger.info("Loaded config.yml!");
+            getProxyLogger().info("Loaded config.yml!");
         }else{
-            logger.warn("Couldn't load config.yml! Check above lines for errors and warnings.");
+            getProxyLogger().warn("Couldn't load config.yml! Check above lines for errors and warnings.");
             return;
         }
     
         List<Integer> protocols = configHandler.getIntList("Protocol", "Versions");
         boolean versionsSet;
         if(protocols.isEmpty()){
-            printWarning(logger);
+            printWarning();
             
             versionsSet = false;
         }else{
-            logger.info("Loaded the following Protocol Version(s):");
-            logger.info(ProtocolVersion.getFriendlyNames(protocols, false));
+            getProxyLogger().info("Loaded the following Protocol Version(s):");
+            getProxyLogger().info(ProtocolVersion.getFriendlyNames(protocols, false));
             
             versionsSet = true;
         }
-        
-        logger.info("Loading command /ovr...");
+    
+        getProxyLogger().info("Loading command /ovr...");
         pluginCore.loadCommands();
-        logger.info("Command loaded!");
-        
-        logger.info("Loading Event Listeners...");
+        getProxyLogger().info("Command loaded!");
+    
+        getProxyLogger().info("Loading Event Listeners...");
         pluginCore.loadEventListeners();
-        logger.info("Event Listeners loaded!");
-        
-        logger.info("Loading Metrics...");
+        getProxyLogger().info("Event Listeners loaded!");
+    
+        getProxyLogger().info("Loading Metrics...");
         if(versionsSet){
             pluginCore.loadMetrics();
-            logger.info("Metrics loaded!");
+            getProxyLogger().info("Metrics loaded!");
         }else{
-            logger.info("No Protocol Versions set. Skipping Metrics initialization...");
+            getProxyLogger().info("No Protocol Versions set. Skipping Metrics initialization...");
         }
-        
-        logger.info("OneVersionRemake is ready!");
+    
+        getProxyLogger().info("OneVersionRemake is ready!");
     }
     
-    private void printBanner(ProxyLogger logger){
-        logger.info("");
-        logger.info("   ____ _    ______");
-        logger.info("  / __ \\ |  / / __ \\");
-        logger.info(" / / / / | / / /_/ /");
-        logger.info("/ /_/ /| |/ / _, _/");
-        logger.info("\\____/ |___/_/ |_|");
-        logger.info("");
-        logger.info("OneVersionRemake v" + getVersion());
-        logger.info("Platform: " + pluginCore.getProxyPlatform().getName());
-        logger.info("");
+    private void printBanner(){
+        getProxyLogger().info("");
+        getProxyLogger().info("   ____ _    ______");
+        getProxyLogger().info("  / __ \\ |  / / __ \\");
+        getProxyLogger().info(" / / / / | / / /_/ /");
+        getProxyLogger().info("/ /_/ /| |/ / _, _/");
+        getProxyLogger().info("\\____/ |___/_/ |_|");
+        getProxyLogger().info("");
+        getProxyLogger().info("OneVersionRemake v" + getVersion());
+        getProxyLogger().info("Platform: " + pluginCore.getProxyPlatform().getName());
+        getProxyLogger().info("");
     }
     
-    private void printWarning(ProxyLogger logger){
-        logger.warn("================================================================================");
-        logger.warn("WARNING!");
-        logger.warn("The config option 'Versions' doesn't contain any protocol numbers!");
-        logger.warn("Please edit the config to include valid protocol numbers or OneVersionRemake");
-        logger.warn("won't work as expected.");
-        logger.warn("");
-        logger.warn("You may find a list of supported protocol versions here:");
-        logger.warn("https://github.com/Andre601/OneVersionRemake/wiki/Supported-Protocols");
-        logger.warn("");
-        logger.warn("OneVersionRemake won't handle joining Players to prevent any possible issues.");
-        logger.warn("================================================================================");
+    private void printWarning(){
+        getProxyLogger().warn("================================================================================");
+        getProxyLogger().warn("WARNING!");
+        getProxyLogger().warn("The config option 'Versions' doesn't contain any protocol numbers!");
+        getProxyLogger().warn("Please edit the config to include valid protocol numbers or OneVersionRemake");
+        getProxyLogger().warn("won't work as expected.");
+        getProxyLogger().warn("");
+        getProxyLogger().warn("You may find a list of supported protocol versions here:");
+        getProxyLogger().warn("https://github.com/Andre601/OneVersionRemake/wiki/Supported-Protocols");
+        getProxyLogger().warn("");
+        getProxyLogger().warn("OneVersionRemake won't handle joining Players to prevent any possible issues.");
+        getProxyLogger().warn("================================================================================");
     }
     
     private void loadVersion(){

--- a/core/src/main/java/com/andre601/oneversionremake/core/commands/CommandHandler.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/commands/CommandHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 - 2021 Andre601
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.andre601.oneversionremake.core.commands;
+
+import com.andre601.oneversionremake.core.CommandPermissions;
+import com.andre601.oneversionremake.core.OneVersionRemake;
+import com.andre601.oneversionremake.core.enums.ProtocolVersion;
+import com.andre601.oneversionremake.core.interfaces.CmdSender;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import java.util.List;
+
+public class CommandHandler{
+    
+    public final OneVersionRemake core;
+    
+    public CommandHandler(OneVersionRemake core){
+        this.core = core;
+    }
+    
+    public void handle(CmdSender sender, String[] args){
+        if(args.length == 0 || args[0].equalsIgnoreCase("help")){
+            if(!sender.hasPermission(CommandPermissions.COMMAND_HELP)){
+                sender.sendMsg(NamedTextColor.RED, "Insufficient permissions!");
+                return;
+            }
+            
+            sender.sendMsg("OneVersionRemake v%s", core.getVersion());
+            sender.sendMsg();
+            sender.sendMsg(NamedTextColor.AQUA, "/ovr help");
+            sender.sendMsg(NamedTextColor.GRAY, "Shows this Command list.");
+            sender.sendMsg();
+            sender.sendMsg(NamedTextColor.AQUA, "/ovr reload");
+            sender.sendMsg(NamedTextColor.GRAY, "Reloads the configuration file.");
+        }else
+        if(args[0].equalsIgnoreCase("reload")){
+            if(!sender.hasPermission(CommandPermissions.COMMAND_RELOAD)){
+                sender.sendMsg(NamedTextColor.RED, "Insufficient permissions!");
+                return;
+            }
+            
+            if(core.reloadConfig()){
+                List<Integer> protocols = core.getConfigHandler().getIntList("Protocol", "Versions");
+                
+                sender.sendMsg(NamedTextColor.AQUA, "Loaded following Minecraft version(s):");
+                if(protocols.isEmpty()){
+                    sender.sendMsg(NamedTextColor.RED, "None");
+                }else{
+                    sender.sendMsg(NamedTextColor.GRAY, ProtocolVersion.getFriendlyNames(protocols, false));
+                }
+                
+                sender.sendMsg();
+                sender.sendMsg(NamedTextColor.GREEN, "Reload successful!");
+            }else{
+                sender.sendMsg(NamedTextColor.RED, "There was an issue while reloading the configuration file!");
+                sender.sendMsg(NamedTextColor.RED, "Please check the Console of the Proxy for any errors and warnings.");
+            }
+        }else{
+            sender.sendMsg(NamedTextColor.RED, "Unknown argument \"%s\".", args[0]);
+            sender.sendMsg(NamedTextColor.RED, "Run \"/ovr help\" for all commands.");
+        }
+    }
+}

--- a/core/src/main/java/com/andre601/oneversionremake/core/interfaces/CmdSender.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/interfaces/CmdSender.java
@@ -22,6 +22,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 
 public interface CmdSender{
     
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     boolean hasPermission(String permission);
     
     void sendMsg();

--- a/core/src/main/java/com/andre601/oneversionremake/core/interfaces/CmdSender.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/interfaces/CmdSender.java
@@ -16,27 +16,17 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.andre601.oneversionremake.velocity.commands;
+package com.andre601.oneversionremake.core.interfaces;
 
-import com.andre601.oneversionremake.velocity.VelocityCore;
-import com.velocitypowered.api.command.SimpleCommand;
+import net.kyori.adventure.text.format.NamedTextColor;
 
-public class CmdOneVersionRemake implements SimpleCommand{
+public interface CmdSender{
     
-    private final VelocityCore plugin;
+    boolean hasPermission(String permission);
     
-    public CmdOneVersionRemake(VelocityCore plugin){
-        this.plugin = plugin;
-    }
+    void sendMsg();
     
-    @Override
-    public void execute(Invocation invocation){
-        String[] args = invocation.arguments();
-        
-        if(plugin.getSender() == null){
-            plugin.setSender(invocation.source());
-        }
-        
-        plugin.getCommandHandler().handle(plugin.getSender(), args);
-    }
+    void sendMsg(String msg, Object... args);
+    
+    void sendMsg(NamedTextColor color, String msg, Object... args);
 }

--- a/core/src/main/java/com/andre601/oneversionremake/core/interfaces/PluginCore.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/interfaces/PluginCore.java
@@ -18,6 +18,7 @@
 
 package com.andre601.oneversionremake.core.interfaces;
 
+import com.andre601.oneversionremake.core.commands.CommandHandler;
 import com.andre601.oneversionremake.core.enums.ProxyPlatform;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 
@@ -31,8 +32,6 @@ public interface PluginCore{
     
     void loadMetrics();
     
-    boolean reloadConfig();
-    
     Path getPath();
     
     ProxyPlatform getProxyPlatform();
@@ -40,6 +39,8 @@ public interface PluginCore{
     ProxyLogger getProxyLogger();
     
     ConfigHandler getConfigHandler();
+    
+    CommandHandler getCommandHandler();
     
     String getVersion();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <plugin.version>3.2.2</plugin.version>
+        <plugin.version>3.3.0</plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -19,17 +19,20 @@
 package com.andre601.oneversionremake.velocity;
 
 import com.andre601.oneversionremake.core.OneVersionRemake;
+import com.andre601.oneversionremake.core.commands.CommandHandler;
 import com.andre601.oneversionremake.core.enums.ProtocolVersion;
 import com.andre601.oneversionremake.core.enums.ProxyPlatform;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
 import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
 import com.andre601.oneversionremake.velocity.commands.CmdOneVersionRemake;
+import com.andre601.oneversionremake.velocity.commands.VelocitySender;
 import com.andre601.oneversionremake.velocity.listener.VelocityLoginListener;
 import com.andre601.oneversionremake.velocity.listener.VelocityPingListener;
 import com.andre601.oneversionremake.velocity.logging.VelocityLogger;
 import com.google.inject.Inject;
 import com.velocitypowered.api.command.CommandMeta;
+import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
@@ -52,6 +55,8 @@ public class VelocityCore implements PluginCore{
     private final Metrics.Factory factory;
     
     private OneVersionRemake core;
+    
+    private VelocitySender sender = null;
     
     @Inject
     public VelocityCore(ProxyServer proxy, @DataDirectory Path path, Metrics.Factory factory){
@@ -122,11 +127,6 @@ public class VelocityCore implements PluginCore{
     }
     
     @Override
-    public boolean reloadConfig(){
-        return core.reloadConfig();
-    }
-    
-    @Override
     public Path getPath(){
         return path;
     }
@@ -147,11 +147,24 @@ public class VelocityCore implements PluginCore{
     }
     
     @Override
+    public CommandHandler getCommandHandler(){
+        return core.getCommandHandler();
+    }
+    
+    @Override
     public String getVersion(){
         return core.getVersion();
     }
     
     public ProxyServer getProxy(){
         return proxy;
+    }
+    
+    public VelocitySender getSender(){
+        return sender;
+    }
+    
+    public void setSender(CommandSource sender){
+        this.sender = new VelocitySender(sender);
     }
 }

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -26,13 +26,11 @@ import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
 import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
 import com.andre601.oneversionremake.velocity.commands.CmdOneVersionRemake;
-import com.andre601.oneversionremake.velocity.commands.VelocitySender;
 import com.andre601.oneversionremake.velocity.listener.VelocityLoginListener;
 import com.andre601.oneversionremake.velocity.listener.VelocityPingListener;
 import com.andre601.oneversionremake.velocity.logging.VelocityLogger;
 import com.google.inject.Inject;
 import com.velocitypowered.api.command.CommandMeta;
-import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
@@ -55,8 +53,6 @@ public class VelocityCore implements PluginCore{
     private final Metrics.Factory factory;
     
     private OneVersionRemake core;
-    
-    private VelocitySender sender = null;
     
     @Inject
     public VelocityCore(ProxyServer proxy, @DataDirectory Path path, Metrics.Factory factory){
@@ -158,13 +154,5 @@ public class VelocityCore implements PluginCore{
     
     public ProxyServer getProxy(){
         return proxy;
-    }
-    
-    public VelocitySender getSender(){
-        return sender;
-    }
-    
-    public void setSender(CommandSource sender){
-        this.sender = new VelocitySender(sender);
     }
 }

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/commands/CmdOneVersionRemake.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/commands/CmdOneVersionRemake.java
@@ -31,12 +31,9 @@ public class CmdOneVersionRemake implements SimpleCommand{
     
     @Override
     public void execute(Invocation invocation){
+        VelocitySender sender = new VelocitySender(invocation.source());
         String[] args = invocation.arguments();
         
-        if(plugin.getSender() == null){
-            plugin.setSender(invocation.source());
-        }
-        
-        plugin.getCommandHandler().handle(plugin.getSender(), args);
+        plugin.getCommandHandler().handle(sender, args);
     }
 }

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/commands/VelocitySender.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/commands/VelocitySender.java
@@ -18,6 +18,7 @@
 
 package com.andre601.oneversionremake.velocity.commands;
 
+import com.andre601.oneversionremake.core.CommandPermissions;
 import com.andre601.oneversionremake.core.interfaces.CmdSender;
 import com.velocitypowered.api.command.CommandSource;
 import net.kyori.adventure.text.Component;
@@ -33,7 +34,7 @@ public class VelocitySender implements CmdSender{
     
     @Override
     public boolean hasPermission(String permission){
-        return sender.hasPermission(permission);
+        return sender.hasPermission(permission) || sender.hasPermission(CommandPermissions.ADMIN);
     }
     
     @Override

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/commands/VelocitySender.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/commands/VelocitySender.java
@@ -18,25 +18,36 @@
 
 package com.andre601.oneversionremake.velocity.commands;
 
-import com.andre601.oneversionremake.velocity.VelocityCore;
-import com.velocitypowered.api.command.SimpleCommand;
+import com.andre601.oneversionremake.core.interfaces.CmdSender;
+import com.velocitypowered.api.command.CommandSource;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
-public class CmdOneVersionRemake implements SimpleCommand{
+public class VelocitySender implements CmdSender{
     
-    private final VelocityCore plugin;
+    private final CommandSource sender;
     
-    public CmdOneVersionRemake(VelocityCore plugin){
-        this.plugin = plugin;
+    public VelocitySender(CommandSource sender){
+        this.sender = sender;
     }
     
     @Override
-    public void execute(Invocation invocation){
-        String[] args = invocation.arguments();
-        
-        if(plugin.getSender() == null){
-            plugin.setSender(invocation.source());
-        }
-        
-        plugin.getCommandHandler().handle(plugin.getSender(), args);
+    public boolean hasPermission(String permission){
+        return sender.hasPermission(permission);
+    }
+    
+    @Override
+    public void sendMsg(){
+        sendMsg("");
+    }
+    
+    @Override
+    public void sendMsg(String msg, Object... args){
+        sendMsg(NamedTextColor.WHITE, msg, args);
+    }
+    
+    @Override
+    public void sendMsg(NamedTextColor color, String msg, Object... args){
+        sender.sendMessage(Component.text(String.format(msg, args)).color(color));
     }
 }


### PR DESCRIPTION
Version 3.3.0 moves the command stuff into a more generic command handler by having a CmdSender interface for send and perm check methods.
It also has a main command handler class accepting the sender.