### PR TITLE
Make a getPie() method for DrilldownPie Charts

### DIFF
--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
@@ -31,6 +31,7 @@ import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.bstats.bungeecord.Metrics;
+import org.bstats.charts.DrilldownPie;
 
 import java.nio.file.Path;
 
@@ -62,7 +63,7 @@ public class BungeeCore extends Plugin implements PluginCore{
     public void loadMetrics(){
         Metrics metrics = new Metrics(this, 10340);
         
-        metrics.addCustomChart(core.getPie());
+        metrics.addCustomChart(new DrilldownPie("allowed_protocols", () -> core.getPieMap()));
     }
     
     @Override

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
@@ -24,7 +24,6 @@ import com.andre601.oneversionremake.bungeecord.listener.BungeePingListener;
 import com.andre601.oneversionremake.bungeecord.logging.BungeeLogger;
 import com.andre601.oneversionremake.core.OneVersionRemake;
 import com.andre601.oneversionremake.core.commands.CommandHandler;
-import com.andre601.oneversionremake.core.enums.ProtocolVersion;
 import com.andre601.oneversionremake.core.enums.ProxyPlatform;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
@@ -32,12 +31,8 @@ import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.bstats.bungeecord.Metrics;
-import org.bstats.charts.DrilldownPie;
 
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class BungeeCore extends Plugin implements PluginCore{
     
@@ -67,37 +62,7 @@ public class BungeeCore extends Plugin implements PluginCore{
     public void loadMetrics(){
         Metrics metrics = new Metrics(this, 10340);
         
-        metrics.addCustomChart(new DrilldownPie("allowed_versions", () -> {
-            Map<String, Map<String, Integer>> map = new HashMap<>();
-    
-            List<Integer> protocolVersions = getConfigHandler().getIntList("Protocol", "Versions");
-            if(protocolVersions.isEmpty()){
-                String unknown = ProtocolVersion.getFriendlyName(0);
-    
-                Map<String, Integer> entry = new HashMap<>();
-                
-                entry.put(unknown, 1);
-                map.put("other", entry);
-        
-                return map;
-            }
-    
-            for(int version : protocolVersions){
-                String major = ProtocolVersion.getMajor(version);
-                String name = ProtocolVersion.getFriendlyName(version);
-    
-                Map<String, Integer> entry = new HashMap<>();
-        
-                entry.put(name, 1);
-                if(major.equalsIgnoreCase("?")){
-                    map.put("other", entry);
-                }else{
-                    map.put(major, entry);
-                }
-            }
-    
-            return map;
-        }));
+        metrics.addCustomChart(core.getPie());
     }
     
     @Override

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,12 +63,6 @@
             <version>4.7.0</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bstats</groupId>
-            <artifactId>bstats-base</artifactId>
-            <version>2.2.1</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
     
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,6 +63,12 @@
             <version>4.7.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-base</artifactId>
+            <version>2.2.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
@@ -23,7 +23,6 @@ import com.andre601.oneversionremake.core.enums.ProtocolVersion;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
 import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
-import org.bstats.charts.DrilldownPie;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,37 +67,36 @@ public class OneVersionRemake{
         return commandHandler;
     }
     
-    public DrilldownPie getPie(){
-        return new DrilldownPie("allowed_protocols", () -> {
-            Map<String, Map<String, Integer>> map = new HashMap<>();
+    public Map<String, Map<String, Integer>> getPieMap(){
+        Map<String, Map<String, Integer>> map = new HashMap<>();
+        
+        List<Integer> versions = getConfigHandler().getIntList("Protocol", "Versions");
+        if(versions.isEmpty()){
+            String unknown = ProtocolVersion.getFriendlyName(0);
             
-            List<Integer> versions = getConfigHandler().getIntList("Protocol", "Versions");
-            if(versions.isEmpty()){
-                String unknown = ProtocolVersion.getFriendlyName(0);
-                
-                Map<String, Integer> entry = new HashMap<>();
-                
-                entry.put(unknown, 1);
-                map.put("other", entry);
-                
-                return map;
-            }
+            Map<String, Integer> entry = new HashMap<>();
             
-            for(int version : versions){
-                String major = ProtocolVersion.getMajor(version);
-                String name = ProtocolVersion.getFriendlyName(version);
-                
-                Map<String, Integer> entry = new HashMap<>();
-                entry.put(name, 1);
-                if(major.equalsIgnoreCase("?")){
-                    map.put("other", entry);
-                }else{
-                    map.put(major, entry);
-                }
-            }
+            entry.put(unknown, 1);
+            map.put("other", entry);
             
             return map;
-        });
+        }
+        
+        for(int version : versions){
+            String major = ProtocolVersion.getMajor(version);
+            String name = ProtocolVersion.getFriendlyName(version);
+            
+            Map<String, Integer> entry = new HashMap<>();
+            entry.put(name, 1);
+            
+            if(major.equalsIgnoreCase("?")){
+                map.put("other", entry);
+            }else{
+                map.put(major, entry);
+            }
+        }
+        
+        return map;
     }
     
     private void start(){

--- a/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
@@ -23,10 +23,13 @@ import com.andre601.oneversionremake.core.enums.ProtocolVersion;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
 import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
+import org.bstats.charts.DrilldownPie;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 public class OneVersionRemake{
@@ -63,6 +66,39 @@ public class OneVersionRemake{
     
     public CommandHandler getCommandHandler(){
         return commandHandler;
+    }
+    
+    public DrilldownPie getPie(){
+        return new DrilldownPie("allowed_protocols", () -> {
+            Map<String, Map<String, Integer>> map = new HashMap<>();
+            
+            List<Integer> versions = getConfigHandler().getIntList("Protocol", "Versions");
+            if(versions.isEmpty()){
+                String unknown = ProtocolVersion.getFriendlyName(0);
+                
+                Map<String, Integer> entry = new HashMap<>();
+                
+                entry.put(unknown, 1);
+                map.put("other", entry);
+                
+                return map;
+            }
+            
+            for(int version : versions){
+                String major = ProtocolVersion.getMajor(version);
+                String name = ProtocolVersion.getFriendlyName(version);
+                
+                Map<String, Integer> entry = new HashMap<>();
+                entry.put(name, 1);
+                if(major.equalsIgnoreCase("?")){
+                    map.put("other", entry);
+                }else{
+                    map.put(major, entry);
+                }
+            }
+            
+            return map;
+        });
     }
     
     private void start(){

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <plugin.version>3.3.0</plugin.version>
+        <plugin.version>3.3.1</plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -88,38 +88,8 @@ public class VelocityCore implements PluginCore{
     @Override
     public void loadMetrics(){
         Metrics metrics = factory.make(this, 10341);
-        
-        metrics.addCustomChart(new DrilldownPie("allowed_versions", () -> {
-            Map<String, Map<String, Integer>> map = new HashMap<>();
-            
-            List<Integer> protocolVersions = getConfigHandler().getIntList("Protocol", "Versions");
-            if(protocolVersions.isEmpty()){
-                String unknown = ProtocolVersion.getFriendlyName(0);
-                
-                Map<String, Integer> entry = new HashMap<>();
-                
-                entry.put(unknown, 1);
-                map.put("other", entry);
-                
-                return map;
-            }
-            
-            for(int version : protocolVersions){
-                String major = ProtocolVersion.getMajor(version);
-                String name = ProtocolVersion.getFriendlyName(version);
     
-                Map<String, Integer> entry = new HashMap<>();
-                
-                entry.put(name, 1);
-                if(major.equalsIgnoreCase("?")){
-                    map.put("other", entry);
-                }else{
-                    map.put(major, entry);
-                }
-            }
-            
-            return map;
-        }));
+        metrics.addCustomChart(core.getPie());
     }
     
     @Override

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -20,7 +20,6 @@ package com.andre601.oneversionremake.velocity;
 
 import com.andre601.oneversionremake.core.OneVersionRemake;
 import com.andre601.oneversionremake.core.commands.CommandHandler;
-import com.andre601.oneversionremake.core.enums.ProtocolVersion;
 import com.andre601.oneversionremake.core.enums.ProxyPlatform;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
@@ -35,14 +34,10 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
-import org.bstats.charts.DrilldownPie;
 import org.bstats.velocity.Metrics;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class VelocityCore implements PluginCore{
     

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -34,6 +34,7 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
+import org.bstats.charts.DrilldownPie;
 import org.bstats.velocity.Metrics;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +85,7 @@ public class VelocityCore implements PluginCore{
     public void loadMetrics(){
         Metrics metrics = factory.make(this, 10341);
     
-        metrics.addCustomChart(core.getPie());
+        metrics.addCustomChart(new DrilldownPie("allowed_protocols", () -> core.getPieMap()));
     }
     
     @Override


### PR DESCRIPTION
Added a method which returns a DrilldownPie instance for BStats to use on the respective platform.
Still needs work as it, for whatever reason, is null or something...