### PR TITLE
Use ServerPing#asBuilder for pre-set values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <plugin.version>3.3.2</plugin.version>
+        <plugin.version>3.3.3</plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/listener/VelocityPingListener.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/listener/VelocityPingListener.java
@@ -61,7 +61,7 @@ public class VelocityPingListener{
         List<String> motd = plugin.getConfigHandler().getStringList("Messages", "Motd");
         
         if(!serverProtocols.contains(userProtocol)){
-            ServerPing.Builder builder = ServerPing.builder();
+            ServerPing.Builder builder = ping.asBuilder();
             
             if(!hoverMessage.isEmpty())
                 builder.samplePlayers(getSamplePlayers(hoverMessage, serverProtocols, userProtocol, majorOnly));
@@ -77,12 +77,7 @@ public class VelocityPingListener{
                     motd = motd.subList(0, 1);
                 
                 builder.description(Parser.toTextComponent(motd, serverProtocols, userProtocol, majorOnly));
-            }else{
-                builder.description(ping.getDescriptionComponent());
             }
-            
-            // Prevents breaking favicons
-            ping.getFavicon().ifPresent(builder::favicon);
             
             event.setPing(builder.build());
         }

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/listener/VelocityPingListener.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/listener/VelocityPingListener.java
@@ -48,7 +48,6 @@ public class VelocityPingListener{
         int userProtocol = protocolVersion.getProtocol();
     
         List<Integer> serverProtocols = plugin.getConfigHandler().getIntList("Protocol", "Versions");
-        List<String> hoverMessage = plugin.getConfigHandler().getStringList("Messages", "Hover");
         
         if(serverProtocols.isEmpty())
             return;
@@ -59,6 +58,7 @@ public class VelocityPingListener{
         
         String playerCount = plugin.getConfigHandler().getString("", "Messages", "PlayerCount");
         List<String> motd = plugin.getConfigHandler().getStringList("Messages", "Motd");
+        List<String> hoverMessage = plugin.getConfigHandler().getStringList("Messages", "Hover");
         
         if(!serverProtocols.contains(userProtocol)){
             ServerPing.Builder builder = ping.asBuilder();


### PR DESCRIPTION
## ➕ Added

## ✏️ Changed
- Use `ServerPing#asBuilder()` to get Builder with pre-set values. Maybe fixes #43?

## 🐛 Bugs Fixed