### PR TITLE
Drop Java 8, 9, 10 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <plugin.version>3.4.1</plugin.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
     </properties>
     
     <modules>


### PR DESCRIPTION
## ➕ Added

## ✏️ Changed
- Changed Source and target Version to 11. Now OneVersionRemake only supports Java 11 and newer.

## 🐛 Bugs Fixed