### PR TITLE
Add VELOCITY_LEGACY to ProxyPlatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,25 @@
 BungeeCord plugin based on the original [OneVersion] with improvements in terms of configuration and coding standards.
 
 ## Changes compared to OneVersion
-- Improved code.  
-OneVersionRemake completely rewrote the original plugin and improved it to also support Velocity!
-- Changed configuration.  
-The configuration has been rewritten to provide useful information alongside several options to display text.
-- Support for selected MC releases.  
-The plugin adds a new `{version}` and `{clientVersion}` placeholder which when using it with a supported protocol version displays the supported/used MC version.  
-E.g. the protocol 575 would change `{version}` to `1.15.1`
-- Only allow the versions YOU want!  
-You can list as many protocol versions as you want. Any player not having any of these will be denied access.
+- **Improved code**  
+  OneVersionRemake completely rewrote the original plugin and improved it to also support Velocity!
+- **Changed configuration**  
+  The configuration has been rewritten to provide useful information alongside several options to display text.
+- **Support for selected MC releases**  
+  The plugin adds a new `{version}` and `{clientVersion}` placeholder which when using it with a supported protocol version displays the supported/used MC version.  
+  E.g. the protocol 575 would change `{version}` to `1.15.1`
+- **Only allow the versions YOU want!**  
+  You can list as many protocol versions as you want. Any player not having any of these will be denied access.
 
 ## Build it yourself
-If you want to build the plugin yourself can you just clone this repository to your Desktop using following command:  
+If you want to build the plugin yourself can you just clone this repository to your Desktop using following command:
+
 ```
 git clone https://github.com/Andre601/OneVersionRemake
 ```
 
 After that head over to the new folder using `cd OneVersionRemake` and then execute `mvn clean Install`  
-You should find the plugins in `bungeecord/target` and `velocity/target` respectively (Make sure to NOT use the ones having "original" in their name).
+You should find the plugin jars in `bungeecord/target`, `velocity-legacy/target` and `velocity/target` respectively (Make sure to NOT use the ones having "original" in their name).
 
 ## Contribute
 Any contribution is welcome when it helps improving the plugin's performance.  

--- a/core/src/main/java/com/andre601/oneversionremake/core/enums/ProxyPlatform.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/enums/ProxyPlatform.java
@@ -22,8 +22,8 @@ public enum ProxyPlatform{
     
     BUNGEECORD     ("BungeeCord"),
     WATERFALL      ("Waterfall"),
-    VELOCITY       ("Velocity 2.x"),
-    VELOCITY_LEGACY("Velocity 1.x");
+    VELOCITY       ("Velocity 2"),
+    VELOCITY_LEGACY("Velocity");
     
     private final String name;
     

--- a/core/src/main/java/com/andre601/oneversionremake/core/enums/ProxyPlatform.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/enums/ProxyPlatform.java
@@ -20,9 +20,10 @@ package com.andre601.oneversionremake.core.enums;
 
 public enum ProxyPlatform{
     
-    BUNGEECORD("BungeeCord"),
-    WATERFALL ("Waterfall"),
-    VELOCITY  ("Velocity");
+    BUNGEECORD     ("BungeeCord"),
+    WATERFALL      ("Waterfall"),
+    VELOCITY       ("Velocity 2.x"),
+    VELOCITY_LEGACY("Velocity 1.x");
     
     private final String name;
     

--- a/velocity-legacy/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity-legacy/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -98,7 +98,7 @@ public class VelocityCore implements PluginCore{
     
     @Override
     public ProxyPlatform getProxyPlatform(){
-        return ProxyPlatform.VELOCITY;
+        return ProxyPlatform.VELOCITY_LEGACY;
     }
     
     @Override


### PR DESCRIPTION
The `velocity-legacy` module is now using the `VELOCITY_LEGACY` ProxyPlatform, which returns `Velocity` while the `VELOCITY` ProxyPlatform returns `Velocity 2`