### PR TITLE
Fully support Velocity 2

### DIFF
--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/BungeeCore.java
@@ -105,6 +105,13 @@ public class BungeeCore extends Plugin implements PluginCore{
         return core.getVersion();
     }
     
+    @Override
+    public String getProxyVersion(){
+        String[] version = getProxy().getVersion().split(":");
+        
+        return String.format("%s (Build #%s)", version[2], version[4]);
+    }
+    
     public ServerPing.PlayerInfo[] getPlayers(List<String> lines, List<Integer> serverProtocols, int userProtocol, boolean majorOnly){
         return core.getPlayers(ServerPing.PlayerInfo.class, lines, serverProtocols, userProtocol, majorOnly)
                    .toArray(new ServerPing.PlayerInfo[0]);

--- a/bungeecord/src/main/resources/plugin.yml
+++ b/bungeecord/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: OneVersionRemake
 author: Andre_601
 version: ${project.version}
+description: ${project.description}
 
 main: com.andre601.oneversionremake.bungeecord.BungeeCore
 

--- a/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
@@ -20,6 +20,7 @@ package com.andre601.oneversionremake.core;
 
 import com.andre601.oneversionremake.core.commands.CommandHandler;
 import com.andre601.oneversionremake.core.enums.ProtocolVersion;
+import com.andre601.oneversionremake.core.enums.ProxyPlatform;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
 import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
@@ -118,6 +119,14 @@ public class OneVersionRemake{
     
     private void start(){
         loadVersion();
+        
+        if((pluginCore.getProxyPlatform() != ProxyPlatform.BUNGEECORD) && (pluginCore.getProxyPlatform() != ProxyPlatform.WATERFALL)){
+            if((isNewVelocity() && isLegacyPlugin()) || (!isNewVelocity() && !isLegacyPlugin())){
+                printIncompatabilityWarning();
+                return;
+            }
+        }
+        
         printBanner();
         
         if(configHandler.loadConfig()){
@@ -168,7 +177,7 @@ public class OneVersionRemake{
         getProxyLogger().info("\\____/ |___/_/ |_|");
         getProxyLogger().info("");
         getProxyLogger().info("OneVersionRemake v" + getVersion());
-        getProxyLogger().info("Platform: " + pluginCore.getProxyPlatform().getName());
+        getProxyLogger().info("Platform: " + pluginCore.getProxyPlatform().getName() + " v" + pluginCore.getProxyVersion());
         getProxyLogger().info("");
     }
     
@@ -186,6 +195,15 @@ public class OneVersionRemake{
         getProxyLogger().warn("================================================================================");
     }
     
+    private void printIncompatabilityWarning(){
+        getProxyLogger().warn("================================================================================");
+        getProxyLogger().warn("WARNING!");
+        getProxyLogger().warn("You're using Velocity 2 while the plugin itself is for Velocity 1.1.0!");
+        getProxyLogger().warn("");
+        getProxyLogger().warn("The Legacy-plugin is incompatible with Velocity 2 and will be disabled...");
+        getProxyLogger().warn("================================================================================");
+    }
+    
     private void loadVersion(){
         try(InputStream is = getClass().getResourceAsStream("/core.properties")){
             Properties properties = new Properties();
@@ -196,5 +214,19 @@ public class OneVersionRemake{
         }catch(IOException ex){
             version = "UNKNOWN";
         }
+    }
+    
+    private boolean isNewVelocity(){
+        try{
+            int maj = Integer.parseInt(pluginCore.getProxyVersion().split("\\.")[0]);
+            
+            return maj >= 2;
+        }catch(NumberFormatException ex){
+            return false;
+        }
+    }
+    
+    private boolean isLegacyPlugin(){
+        return pluginCore.getProxyPlatform() == ProxyPlatform.VELOCITY_LEGACY;
     }
 }

--- a/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
@@ -20,7 +20,6 @@ package com.andre601.oneversionremake.core;
 
 import com.andre601.oneversionremake.core.commands.CommandHandler;
 import com.andre601.oneversionremake.core.enums.ProtocolVersion;
-import com.andre601.oneversionremake.core.enums.ProxyPlatform;
 import com.andre601.oneversionremake.core.files.ConfigHandler;
 import com.andre601.oneversionremake.core.interfaces.PluginCore;
 import com.andre601.oneversionremake.core.interfaces.ProxyLogger;
@@ -119,14 +118,6 @@ public class OneVersionRemake{
     
     private void start(){
         loadVersion();
-        
-        if((pluginCore.getProxyPlatform() != ProxyPlatform.BUNGEECORD) && (pluginCore.getProxyPlatform() != ProxyPlatform.WATERFALL)){
-            if((isNewVelocity() && isLegacyPlugin()) || (!isNewVelocity() && !isLegacyPlugin())){
-                printIncompatabilityWarning();
-                return;
-            }
-        }
-        
         printBanner();
         
         if(configHandler.loadConfig()){
@@ -195,15 +186,6 @@ public class OneVersionRemake{
         getProxyLogger().warn("================================================================================");
     }
     
-    private void printIncompatabilityWarning(){
-        getProxyLogger().warn("================================================================================");
-        getProxyLogger().warn("WARNING!");
-        getProxyLogger().warn("You're using Velocity 2 while the plugin itself is for Velocity 1.1.0!");
-        getProxyLogger().warn("");
-        getProxyLogger().warn("The Legacy-plugin is incompatible with Velocity 2 and will be disabled...");
-        getProxyLogger().warn("================================================================================");
-    }
-    
     private void loadVersion(){
         try(InputStream is = getClass().getResourceAsStream("/core.properties")){
             Properties properties = new Properties();
@@ -214,19 +196,5 @@ public class OneVersionRemake{
         }catch(IOException ex){
             version = "UNKNOWN";
         }
-    }
-    
-    private boolean isNewVelocity(){
-        try{
-            int maj = Integer.parseInt(pluginCore.getProxyVersion().split("\\.")[0]);
-            
-            return maj >= 2;
-        }catch(NumberFormatException ex){
-            return false;
-        }
-    }
-    
-    private boolean isLegacyPlugin(){
-        return pluginCore.getProxyPlatform() == ProxyPlatform.VELOCITY_LEGACY;
     }
 }

--- a/core/src/main/java/com/andre601/oneversionremake/core/interfaces/PluginCore.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/interfaces/PluginCore.java
@@ -43,4 +43,6 @@ public interface PluginCore{
     CommandHandler getCommandHandler();
     
     String getVersion();
+    
+    String getProxyVersion();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
         <plugin.version>3.5.0</plugin.version>
+        <plugin.description>Only allow specific client versions on your Network.</plugin.description>
+        
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
-        <plugin.version>3.5.0</plugin.version>
+        <plugin.version>3.5.1</plugin.version>
         <plugin.description>Only allow specific client versions on your Network.</plugin.description>
         
         <maven.compiler.target>11</maven.compiler.target>

--- a/velocity-legacy/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity-legacy/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -121,6 +121,11 @@ public class VelocityCore implements PluginCore{
         return core.getVersion();
     }
     
+    @Override
+    public String getProxyVersion(){
+        return getProxy().getVersion().getVersion();
+    }
+    
     public ProxyServer getProxy(){
         return proxy;
     }

--- a/velocity-legacy/src/main/resources/velocity-plugin.json
+++ b/velocity-legacy/src/main/resources/velocity-plugin.json
@@ -2,7 +2,7 @@
   "id": "oneversionremake",
   "name": "OneVersionRemake",
   "version": "${project.version}",
-  "description": "Block connections from Players with versions not matching your Network's.",
+  "description": "${project.description}",
   "authors": [
     "Andre_601"
   ],

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -25,6 +25,7 @@
     <artifactId>velocity</artifactId>
     <packaging>jar</packaging>
     <version>${plugin.version}</version>
+    <description>${plugin.description}</description>
 
     <parent>
         <artifactId>parent</artifactId>

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -121,6 +121,11 @@ public class VelocityCore implements PluginCore{
         return core.getVersion();
     }
     
+    @Override
+    public String getProxyVersion(){
+        return getProxy().version().version();
+    }
+    
     public ProxyServer getProxy(){
         return proxy;
     }

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/VelocityCore.java
@@ -35,8 +35,6 @@ import com.velocitypowered.api.event.lifecycle.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
-import org.bstats.charts.DrilldownPie;
-import org.bstats.velocity.Metrics;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
@@ -48,17 +46,13 @@ public class VelocityCore implements PluginCore{
     private final ProxyServer proxy;
     private final Path path;
     
-    private final Metrics.Factory factory;
-    
     private OneVersionRemake core;
     
-    @Inject
-    public VelocityCore(ProxyServer proxy, @DataDirectory Path path, Metrics.Factory factory){
+    @Inject // TODO: Re-Add Metrics.Factory factory once Velocity 2 supports it
+    public VelocityCore(ProxyServer proxy, @DataDirectory Path path){
         this.logger = new VelocityLogger(LoggerFactory.getLogger("OneVersionRemake"));
         this.proxy = proxy;
         this.path = path;
-        
-        this.factory = factory;
     }
     
     @Subscribe
@@ -86,9 +80,11 @@ public class VelocityCore implements PluginCore{
     
     @Override
     public void loadMetrics(){
-        Metrics metrics = factory.make(this, 10341);
+        // TODO: Re-Add Metrics once available for Velocity 2
+        //Metrics metrics = factory.make(this, 10341);
         
-        metrics.addCustomChart(new DrilldownPie("allowed_protocols", () -> core.getPieMap()));
+        //metrics.addCustomChart(new DrilldownPie("allowed_protocols", () -> core.getPieMap()));
+        
     }
     
     @Override

--- a/velocity/src/main/resources/velocity-plugin-info.json
+++ b/velocity/src/main/resources/velocity-plugin-info.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "oneversionremake",
+    "name": "OneVersionRemake",
+    "version": "${project.version}",
+    "description": "${project.description}",
+    "authors": [
+      "Andre_601"
+    ],
+    "main": "com.andre601.oneversionremake.velocity.VelocityCore"
+  }
+]


### PR DESCRIPTION
So.... the previous version actually didn't support Velocity 2 since it lacked a `velocity-plugin-info.json` file.

I also took the time to implement some other stuff like retrieving and displaying the Proxy version.