### PR TITLE
Version 3.9.0

### DIFF
--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/listener/BungeeLoginListener.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/listener/BungeeLoginListener.java
@@ -57,12 +57,12 @@ public class BungeeLoginListener implements Listener{
             event.setCancelled(true);
             
             if(plugin.getConfigHandler().getBoolean(true, "Protocol", "LogDenial")){
-                plugin.getProxyLogger().info(String.format(
-                        "Denied login for Player %s with MC version %s (Protocol Version %d)",
+                plugin.getProxyLogger().infoFormat(
+                        "Denied login for Player %s with MC version %s (Protocol version: %d)",
                         event.getConnection().getName(),
                         plugin.getProtocolVersionResolver().getFriendlyName(userProtocol),
                         userProtocol
-                ));
+                );
             }
         }
     }

--- a/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/logging/BungeeLogger.java
+++ b/bungeecord/src/main/java/com/andre601/oneversionremake/bungeecord/logging/BungeeLogger.java
@@ -37,8 +37,18 @@ public class BungeeLogger implements ProxyLogger{
     }
     
     @Override
+    public void infoFormat(String msg, Object... args){
+        info(String.format(msg, args));
+    }
+    
+    @Override
     public void warn(String msg){
         logger.log(Level.WARNING, msg);
+    }
+    
+    @Override
+    public void warnFormat(String msg, Object... args){
+        warn(String.format(msg, args));
     }
     
     @Override

--- a/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/OneVersionRemake.java
@@ -32,6 +32,8 @@ import java.util.*;
 
 public class OneVersionRemake{
     
+    private static final String DEF_VERSIONS_URL = "https://www.andre601.ch/oneversionremake/versions.json";
+    
     private final PluginCore pluginCore;
     private final ConfigHandler configHandler;
     private final CommandHandler commandHandler;
@@ -140,7 +142,9 @@ public class OneVersionRemake{
         }
         
         if(!getProtocolVersionResolver().hasFile() || getConfigHandler().getBoolean(true, "Settings", "UpdateVersions")){
-            if(getProtocolVersionResolver().loadFile()){
+            String url = getConfigHandler().getString(DEF_VERSIONS_URL, "Settings", "VersionsUrl");
+            
+            if(getProtocolVersionResolver().loadFile(url)){
                 getProxyLogger().info("Updated versions.json!");
                 enable();
             }else{
@@ -197,8 +201,8 @@ public class OneVersionRemake{
         getProxyLogger().info("/ /_/ /| |/ / _, _/");
         getProxyLogger().info("\\____/ |___/_/ |_|");
         getProxyLogger().info("");
-        getProxyLogger().info("OneVersionRemake v" + getVersion());
-        getProxyLogger().info("Platform: " + pluginCore.getProxyPlatform().getName() + " v" + pluginCore.getProxyVersion());
+        getProxyLogger().infoFormat("OneVersionRemake v%s", getVersion());
+        getProxyLogger().infoFormat("Platform: %s v%s", pluginCore.getProxyPlatform().getName(), pluginCore.getProxyVersion());
         getProxyLogger().info("");
     }
     

--- a/core/src/main/java/com/andre601/oneversionremake/core/interfaces/ProxyLogger.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/interfaces/ProxyLogger.java
@@ -22,7 +22,11 @@ public interface ProxyLogger{
     
     void info(String msg);
     
+    void infoFormat(String msg, Object... args);
+    
     void warn(String msg);
+    
+    void warnFormat(String msg, Object... args);
     
     void warn(String msg, Throwable throwable);
 }

--- a/core/src/main/java/com/andre601/oneversionremake/core/proxy/ProtocolVersionResolver.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/proxy/ProtocolVersionResolver.java
@@ -57,13 +57,13 @@ public class ProtocolVersionResolver{
         return file.toFile().exists();
     }
     
-    public boolean loadFile(){
+    public boolean loadFile(String url){
         if(!path.toFile().isDirectory() && !path.toFile().mkdirs()){
             logger.warn("Could not create folder for plugin!");
             return false;
         }
         
-        return updateCache();
+        return updateCache(url);
     }
     
     public boolean setupConfigurate(){
@@ -81,8 +81,7 @@ public class ProtocolVersionResolver{
         return true;
     }
     
-    public boolean updateCache(){
-        String url = "https://raw.githubusercontent.com/Andre601/OneVersionRemake/master/versions.json";
+    public boolean updateCache(String url){
         Request request = new Request.Builder()
                 .url(url)
                 .addHeader("User-Agent", "OneVersionRemake")
@@ -97,10 +96,10 @@ public class ProtocolVersionResolver{
                 ));
                 switch(response.code()){
                     case 404:
-                        logger.warn(String.format(
-                                "The requested site (%s) does not exist. Please report this to the developer on Discord!",
+                        logger.warnFormat(
+                                "The requested url (%s) does not exist. Please check that the URL is valid!",
                                 url
-                        ));
+                        );
                         break;
                         
                         case 429:
@@ -108,11 +107,17 @@ public class ProtocolVersionResolver{
                             break;
                         
                         case 500:
-                            logger.warn("The Site (GitHub.com) encountered an error when handling the request. Try again later...");
+                            logger.warnFormat(
+                                    "The Website (%s) encountered an error when handling the request. Try again later...",
+                                    url
+                            );
                             break;
                         
                         default:
-                            logger.warn("This is an unknown error by the plugin! Please report this to the developer on Discord!");
+                            logger.warnFormat(
+                                    "The plugin received a not known HTTPS status code %d. Please report this to the Developer!",
+                                    response.code()
+                            );
                             break;
                 }
                 return false;
@@ -120,7 +125,7 @@ public class ProtocolVersionResolver{
             
             ResponseBody body = response.body();
             if(body == null){
-                logger.warn("GitHub.com returned an invalid/empty body!");
+                logger.warnFormat("Received empty/null body from '%s'", url);
                 return false;
             }
             

--- a/core/src/main/java/com/andre601/oneversionremake/core/proxy/ProxyPlatform.java
+++ b/core/src/main/java/com/andre601/oneversionremake/core/proxy/ProxyPlatform.java
@@ -27,8 +27,7 @@ public enum ProxyPlatform{
     WATERFALL      ("Waterfall"),
     
     // Velocity
-    VELOCITY       ("Velocity 3"),
-    VELOCITY_LEGACY("Velocity");
+    VELOCITY       ("Velocity");
     
     private final String name;
     

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -15,73 +15,80 @@
 #
 # Created with Version ${project.version}
 #
-# +---------------------------------------------------------------------------+
-# |                               Main Settings                               |
-# |                                                                           |
-# | Main Settings for the plugin.                                             |
-# |                                                                           |
-# | https://github.com/Andre601/OneVersionRemake/wiki/Config#settings         |
-# +---------------------------------------------------------------------------+
+# +----------------------------------------------------------------------------+
+# |                               Main Settings                                |
+# |                                                                            |
+# | Main Settings for the plugin.                                              |
+# |                                                                            |
+# | https://github.com/Andre601/OneVersionRemake/wiki/Config#settings          |
+# +----------------------------------------------------------------------------+
 Settings:
-  # +-------------------------------------------------------------------------+
-  # | Whether OneVersionRemake should download the latest versions.json on    |
-  # | Proxy (re)start.                                                        |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#updateversions |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | Whether OneVersionRemake should download the latest versions.json on     |
+  # | Proxy (re)start.                                                         |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#updateversions  |
+  # +--------------------------------------------------------------------------+
   UpdateVersions: true
+  # +--------------------------------------------------------------------------+
+  # | URL pointing to the file that contains the different Protocols OVR       |
+  # | should use.                                                              |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#versionsurl     |
+  # +--------------------------------------------------------------------------+
+  VersionsUrl: 'https://www.andre601.ch/oneversionremake/versions.json'
 
-# +---------------------------------------------------------------------------+
-# |                             Protocol Settings                             |
-# |                                                                           |
-# | Protocol Settings for the plugin.                                         |
-# |                                                                           |
-# | https://github.com/Andre601/OneVersionRemake/wiki/Config#protocol         |
-# +---------------------------------------------------------------------------+
+# +----------------------------------------------------------------------------+
+# |                             Protocol Settings                              |
+# |                                                                            |
+# | Protocol Settings for the plugin.                                          |
+# |                                                                            |
+# | https://github.com/Andre601/OneVersionRemake/wiki/Config#protocol          |
+# +----------------------------------------------------------------------------+
 Protocol:
-  # +-------------------------------------------------------------------------+
-  # | The Protocol Versions that should be allowed to join the network.       |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#versions       |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | The Protocol Versions that should be allowed to join the network.        |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#versions        |
+  # +--------------------------------------------------------------------------+
   Versions: []
   
-  # +-------------------------------------------------------------------------+
-  # | Should OneVersionRemake log denied Logins in the console?               |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#logdenial      |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | Should OneVersionRemake log denied Logins in the console?                |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#logdenial       |
+  # +--------------------------------------------------------------------------+
   LogDenial: true
   
-  # +-------------------------------------------------------------------------+
-  # | Should the {version} placeholder only show major MC versions?           |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#majoronly      |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | Should the {version} placeholder only show major MC versions?            |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#majoronly       |
+  # +--------------------------------------------------------------------------+
   MajorOnly: false
 
-# +---------------------------------------------------------------------------+
-# |                                 Messages                                  |
-# |                                                                           |
-# | This section contains all the messages that you can configure.            |
-# |                                                                           |
-# | https://github.com/Andre601/OneVersionRemake/wiki/Config#messages         |
-# +---------------------------------------------------------------------------+
+# +----------------------------------------------------------------------------+
+# |                                  Messages                                  |
+# |                                                                            |
+# | This section contains all the messages that you can configure.             |
+# |                                                                            |
+# | https://github.com/Andre601/OneVersionRemake/wiki/Config#messages          |
+# +----------------------------------------------------------------------------+
 Messages:
-  # +-------------------------------------------------------------------------+
-  # | Message to display instead of the Player count (<online>/<max>) next to |
-  # | the ping icon.                                                          |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#playercount    |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | Message to display instead of the Player count (<online>/<max>) next to  |
+  # | the ping icon.                                                           |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#playercount     |
+  # +--------------------------------------------------------------------------+
   PlayerCount: '<red>Minecraft {version}'
   
-  # +-------------------------------------------------------------------------+
-  # | Reason to display, when the player gets kicked for using a unsupported  |
-  # | Minecraft Version.                                                      |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#kick           |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | Reason to display, when the player gets kicked for using a unsupported   |
+  # | Minecraft Version.                                                       |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#kick            |
+  # +--------------------------------------------------------------------------+
   Kick:
   - '<red>You are using an unsupported version of Minecraft ({userVersion})!'
   - '<red>This server supports the following Versions:'
@@ -89,21 +96,21 @@ Messages:
   - ''
   - '<red>Please change your Version and try again.'
 
-  # +-------------------------------------------------------------------------+
-  # | Message to show when the player hovers over the player count with his   |
-  # | cursor.                                                                 |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#hover          |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | Message to show when the player hovers over the player count with his    |
+  # | cursor.                                                                  |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#hover           |
+  # +--------------------------------------------------------------------------+
   Hover:
   - '<red>You are using an unsupported version of Minecraft ({userVersion})!'
   - '<red>Please change your version to {version}.'
 
-  # +-------------------------------------------------------------------------+
-  # | Message to display in the MOTD of the server.                           |
-  # |                                                                         |
-  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#motd           |
-  # +-------------------------------------------------------------------------+
+  # +--------------------------------------------------------------------------+
+  # | Message to display in the MOTD of the server.                            |
+  # |                                                                          |
+  # | https://github.com/Andre601/OneVersionRemake/wiki/Config#motd            |
+  # +--------------------------------------------------------------------------+
   Motd:
   - '<red>Unsupported Minecraft Version {userVersion}'
   - '<red>Please use <gray>{version}</gray>.'

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
-        <plugin.version>3.8.3</plugin.version>
+        <plugin.version>3.9.0</plugin.version>
         <plugin.description>Only allow specific client versions on your Network.</plugin.description>
         
         <maven.compiler.target>11</maven.compiler.target>

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/listener/VelocityLoginListener.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/listener/VelocityLoginListener.java
@@ -55,12 +55,12 @@ public class VelocityLoginListener{
             event.setResult(result);
             
             if(plugin.getConfigHandler().getBoolean(true, "Protocol", "LogDenial")){
-                plugin.getProxyLogger().info(String.format(
-                        "Denied login for Player %s with MC version %s (Protocol Version %d)",
+                plugin.getProxyLogger().infoFormat(
+                        "Denied login for Player %s with MC version %s (Protocol version: %d)",
                         event.getUsername(),
                         plugin.getProtocolVersionResolver().getFriendlyName(userProtocol),
                         userProtocol
-                ));
+                );
             }
         }
     }

--- a/velocity/src/main/java/com/andre601/oneversionremake/velocity/logging/VelocityLogger.java
+++ b/velocity/src/main/java/com/andre601/oneversionremake/velocity/logging/VelocityLogger.java
@@ -35,8 +35,18 @@ public class VelocityLogger implements ProxyLogger{
     }
     
     @Override
+    public void infoFormat(String msg, Object... args){
+        info(String.format(msg, args));
+    }
+    
+    @Override
     public void warn(String msg){
         logger.warn(msg);
+    }
+    
+    @Override
+    public void warnFormat(String msg, Object... args){
+        warn(String.format(msg, args));
     }
     
     @Override

--- a/wiki/Config.md
+++ b/wiki/Config.md
@@ -19,6 +19,7 @@ This page tries to explain each option as detailed as possible!
 ## Contents
 - [Settings](#settings)
   - [UpdateVersions](#updateversions)
+  - [VersionsUrl](#versionsurl)
 - [Protocol](#protocol)
   - [Versions](#versions)
   - [LogDenial](#logdenial)
@@ -44,6 +45,17 @@ Main Settings of the plugin that do not fit any of the other sections.
 > ```
 
 This options sets whether OneVersionRemake should download the latest versions.json or not when enabling.
+
+### VersionsUrl
+> **Type**: `String`  
+> **Default**:  
+> ```yaml
+> VersionsUrl: 'https://www.andre601.ch/oneversionremake/versions.json'
+> ```
+
+With this option can you change the URL from which OneVersionRemake will retrieve the current protocol versions.
+
+When changing the URL, make sure that it points to an actual JSON file (Returns `Content-Type: application/json`) and not an HTML page or similar.
 
 ## Protocol
 This section of the config contains the main settings used for things like determining what versions are allowed on the Network.


### PR DESCRIPTION
## Changes
- The URL from where Velocity should download the versions.json file is now configurable (defaults to https://andre601.ch/oneversionremake/versions.json)
  Add the following to your config.yml to change the URL:
  ```yaml
  Settings:
    VersionsUrl: 'https://andre601.ch/oneversionremake/versions.json'
  ```
- Improved Loggers